### PR TITLE
extending NSImage with high-resolution capable equivalents to initWithContentsOfFile/URL

### DIFF
--- a/NSKit/Extensions/NSImage+NSKitExtensions.h
+++ b/NSKit/Extensions/NSImage+NSKitExtensions.h
@@ -86,4 +86,35 @@
                               bottomWidth:(CGFloat)bottomHeight
                                    toSize:(NSSize)destinationSize
                                 fromImage:(NSImage *)sourceImage;
+
+/**
+ * Initializes and returns a high-resolution capable NSImage 
+ * instance with the contents of the specified URL. Automatically 
+ * loads @2x image (if existing) and adds it to bitmap rep. Both 
+ * images will be combined at runtime to ensure the proper
+ * resolution (regular/retina) is always applied. Use this method 
+ * in favor of "initWithContentsOfURL:".
+ *
+ * @param url The URL identifying the regular-sized image.
+ *
+ * @return NSImage instance, nil if method can't create img rep.
+ *
+ */
+- (id)initWithHiResContentsOfURL:(NSURL *)url;
+	
+/**
+ * Initializes and returns a high-resolution capable NSImage 
+ * instance with the contents of the specified path. Automatically 
+ * loads @2x image (if existing) and adds it to bitmap rep. Both 
+ * images will be combined at runtime to ensure the proper
+ * resolution (regular/retina) is always applied. Use this method 
+ * in favor of "initWithContentsOfFile:".
+ *
+ * @param fileName String containing path to regular-sized image.
+ *
+ * @return NSImage instance, nil if method can't create img rep.
+ *
+ */
+- (id)initWithHiResContentsOfFile:(NSString *)fileName;
+
 @end

--- a/NSKit/Extensions/NSImage+NSKitExtensions.m
+++ b/NSKit/Extensions/NSImage+NSKitExtensions.m
@@ -183,5 +183,54 @@
     return destinationImage;
 }
 
+// ------------------------------------------------------------------------------------------
+#pragma mark - methods
+// ------------------------------------------------------------------------------------------
+
+- (id)initWithHiResContentsOfURL:(NSURL *)url
+{
+    if ((self = [self initWithContentsOfURL:url]))
+    {
+        NSURL *strippedURL = url.URLByDeletingLastPathComponent;
+        NSString *strippedName = url.lastPathComponent.stringByDeletingPathExtension;
+        NSString *ext = url.lastPathComponent.pathExtension;
+        NSString *hiResStrippedName = [NSString stringWithFormat:@"%@@2x", strippedName];
+        NSURL *hiResURL = [strippedURL URLByAppendingPathComponent:
+                           [hiResStrippedName stringByAppendingPathExtension:ext]];
+        
+        if([hiResURL checkResourceIsReachableAndReturnError:NULL] == YES)
+        {
+            NSData *imgData = [[NSData alloc] initWithContentsOfURL:hiResURL];
+            NSBitmapImageRep *imgRep = [[NSBitmapImageRep alloc] initWithData:imgData];
+            
+            imgRep.size = self.size;
+            [self addRepresentation:imgRep];
+        }
+    }
+    return self;
+}
+
+- (id)initWithHiResContentsOfFile:(NSString *)fileName
+{
+    if ((self = [self initWithContentsOfFile:fileName]))
+    {
+        NSString *strippedPath = fileName.stringByDeletingLastPathComponent;
+        NSString *strippedName = fileName.lastPathComponent.stringByDeletingPathExtension;
+        NSString *ext = fileName.lastPathComponent.pathExtension;
+        NSString *hiResStrippedName = [NSString stringWithFormat:@"%@@2x", strippedName];
+        NSString *hiResPath = [strippedPath stringByAppendingPathComponent:
+                               [hiResStrippedName stringByAppendingPathExtension:ext]];
+        
+        if ([[NSFileManager defaultManager] fileExistsAtPath:hiResPath] == YES)
+        {
+            NSData *imgData = [[NSData alloc] initWithContentsOfFile:hiResPath];
+            NSBitmapImageRep *imgRep = [[NSBitmapImageRep alloc] initWithData:imgData];
+            
+            imgRep.size = self.size;
+            [self addRepresentation:imgRep];
+        }
+    }
+    return self;
+}
 
 @end


### PR DESCRIPTION
Hey Patrick! First pull request NSKit. Sadly initWithContentsOfFile: and initWithContentsOfURL: on OS X don't auto-load @2x images as they do on iOS. Time to change that. 
